### PR TITLE
- Fixed wrong comment nesting at Default.aspx (was showing extra empt…

### DIFF
--- a/Default.aspx
+++ b/Default.aspx
@@ -54,6 +54,7 @@
             </div>
         </div>  
       
+<%--   
         <div class="container">
             <div class="row-fluid">
             
@@ -62,14 +63,14 @@
                     <ZoneTemplate>
                         <MonoX:Editor runat="server" ID="editor09" Title='<%$ Code: PageResources.Title_MiddleSection %>' DefaultDocumentTitle='<%$ Code: PageResources.Title_MiddleSection %>'>
                             <DefaultContent>
-                                               
+                            &nbsp;                   
                             </DefaultContent>
                         </MonoX:Editor>
                     </ZoneTemplate>
                     </portal:PortalWebPartZoneTableless>             
                 </div>
-         
-                <%--         
+
+
                 <div class="span6 clearfix" style="position: relative;">
                     <portal:PortalWebPartZoneTableless ID="ForthRightPartZone" CssClass="activities-slideshow" runat="server" Width="100%" ChromeTemplateFile="Standard.htm" HeaderText='<%$ Code: PageResources.Zone_RightPartZone %>'>
                         <ZoneTemplate>
@@ -87,10 +88,11 @@
                     </portal:PortalWebPartZoneTableless>
             		    <p><a class="iframe" style="font-size: 18px; font-weight: 600; padding-top: 10px;" data-fancybox-type="iframe" href="https://docs.google.com/forms/d/1oqBPyNDwVBEK33MwmSeNXEiBthjG5UdYHwJLFTUphmo/viewform?embedded=true">Click here to tell us what you think about trafilm!</a></p>		    
                 </div>     
-                --%>
                 
             </div>
         </div>   
+--%>
+
         
         <div class="container">
             <div class="row-fluid">

--- a/MonoX/MasterPages/PageFooter.ascx
+++ b/MonoX/MasterPages/PageFooter.ascx
@@ -26,7 +26,7 @@ Inherits="MonoSoftware.MonoX.MasterPages.PageFooter" %>
                 <li><a href="http://trafilm.net/default.aspx"><%= PageResources.PageFooter_Home %></a></li>
                 <li><a href="http://trafilm.net/"><%= PageResources.PageFooter_About%>&nbsp;&rsaquo;</a></li>
 		    </ul>
-    	    <ul class="span3">
+    	    <ul class="span3" runat="server" Visible="<% $Code: Page.User.Identity.IsAuthenticated %>"> <%-- TODO: remove the runat="server" and the Visible clause if issue is fixed for these pages to work with non-signedin users --%>
         	    <li><h2><%= PageResources.PageFooter_SocialNetworking %></h2></li>
                 <li><a href='<% $Code: MonoSoftware.MonoX.Utilities.LocalizationUtility.RewriteLink("~/MonoX/Pages/SocialNetworking/Dashboard.aspx") %>' runat="server">Community</a></li>
                 <li><a href='<% $Code: MonoSoftware.MonoX.Utilities.LocalizationUtility.RewriteLink("~/Blog.aspx") %>' runat="server"><%= PageResources.PageFooter_SocialNetworkingBlog %></a></li>


### PR DESCRIPTION
…y section that couldn't be edited to remove some default text shown by MonoX)
- At PageFooter, hiding links to pages that have issue currently with non-signed-in users
